### PR TITLE
Include pico.h before other SDK headers, to define empty macros for b…

### DIFF
--- a/dvi/tmds_encode.S
+++ b/dvi/tmds_encode.S
@@ -1,3 +1,4 @@
+#include "pico.h"
 #include "hardware/regs/addressmap.h"
 #include "hardware/regs/sio.h"
 #include "dvi_config_defs.h"


### PR DESCRIPTION
…oard header

Caused compiler erros in SDK 2.2.0