### PR TITLE
Development

### DIFF
--- a/dvi/dvi.cpp
+++ b/dvi/dvi.cpp
@@ -31,7 +31,7 @@ namespace dvi
         assert(pio_);
         assert(config_);
         assert(timing_);
-
+       
         initSerialiser();
         allocateBuffers(timing);
 
@@ -296,6 +296,12 @@ namespace dvi
     void
     DVI::initSerialiser()
     {
+        // Adjust PIO for gpio pins > 32
+        // The Waveshare RP2350-PiZero is a board that is using gpio pins > 32.
+        if (config_->pinTMDS[0] > 32 || config_->pinTMDS[1] > 32 || config_->pinTMDS[2] > 32)
+        {
+            pio_set_gpio_base(pio_, 16);
+        }
         auto configurePad = [](int gpio, bool invert)
         {
             hw_write_masked(

--- a/dvi/dvi_serialiser.pio
+++ b/dvi/dvi_serialiser.pio
@@ -15,8 +15,10 @@ namespace dvi
 
 inline void serialiserProgramInit(PIO pio, uint sm, uint offset, uint data_pins, uint nWords)
 {
-    pio_sm_set_pins_with_mask(pio, sm, 2u << data_pins, 3u << data_pins);
-    pio_sm_set_pindirs_with_mask(pio, sm, ~0u, 3u << data_pins);
+    // pio_sm_set_pins_with_mask(pio, sm, 2u << data_pins, 3u << data_pins);
+    // pio_sm_set_pindirs_with_mask(pio, sm, ~0u, 3u << data_pins);
+    pio_sm_set_pins_with_mask64(pio, sm, 2ULL << data_pins, 3ULL << data_pins);
+    pio_sm_set_pindirs_with_mask64(pio, sm, ~0ULL, 3ULL << data_pins);
     pio_gpio_init(pio, data_pins);
     pio_gpio_init(pio, data_pins + 1);
 


### PR DESCRIPTION
 Added convertScanBuffer12bpp & convertScanBuffer12bppScaled16_7 added which takes a WORD buffer to render. This makes it possible to use a 320x240 2byte framebuffer on RP2040. Maybe it has to be implemented differently, but it works. 
- Refactor serialiserProgramInit to use 64-bit mask functions for pin configuration, which makes it possible to use gpio pins > 32 for hdmi boards.
- Adjust PIO base for GPIO pins greater than 32 in initSerialiser
- Fix compiler error in Pico SDK 2.2.0
