### PR TITLE
Audio and queue handling

### DIFF
--- a/dvi/dvi.cpp
+++ b/dvi/dvi.cpp
@@ -205,7 +205,9 @@ namespace dvi
             }
             if (audioSampleRing_.getReadableSize() == 0)
             {
-                pendingAudioLineCount_ = 1024; // 枯渇しているようなら 2 frame くらい待ってみる
+                // pendingAudioLineCount_ = 1024; // 枯渇しているようなら 2 frame くらい待ってみる
+                // Backoff for approximately 1 video frame instead of large static penalty
+                pendingAudioLineCount_ = timing_->vFrontPorch + timing_->vSyncWidth + timing_->vBackPorch + timing_->vActiveLines;
             }
 
             audioSamplePos_ += samplesPerLine16_;
@@ -509,7 +511,25 @@ namespace dvi
     void
     DVI::setAudioFreq(int freq, int CTS, int N)
     {
+        // Map/advise on non-standard sample rates: only 32000, 44100, 48000 are explicitly encoded
+        if (!(freq == 32000 || freq == 44100 || freq == 48000))
+        {
+            printf("[DVI] Warning: non-standard audio freq %d Hz requested. InfoFrame will advertise nearest standard.\n", freq);
+        }
         audioFreq_ = freq;
+
+        // If CTS==0, auto-compute a suitable CTS for given N,freq and current pixel clock
+        // Fs = Fpix * N / (128 * CTS)  => CTS = Fpix * N / (128 * Fs)
+        if (CTS == 0 && freq > 0 && N > 0)
+        {
+            uint64_t Fpix = timing_->getPixelClock();
+            printf("Pixel clock %llu Hz, computing CTS for %d Hz, N=%d\n", Fpix, freq, N);
+            uint64_t numerator = Fpix * static_cast<uint64_t>(N);
+            uint64_t denom = static_cast<uint64_t>(128) * static_cast<uint64_t>(freq);
+            CTS = static_cast<int>((numerator + denom / 2) / denom); // rounded
+            // For common 48k/6144 pattern, CTS should equal pixelClock/1000 if pixelClock in Hz multiple of 1k.
+        }
+
         audioClockRegeneration_.setAudioClockRegeneration(CTS, N);
         audioInfoFrame_.setAudioInfoFrame(freq);
 
@@ -522,8 +542,17 @@ namespace dvi
 
         samplesPerFrame_ = static_cast<int>(static_cast<uint64_t>(freq) * nPixPerFrame / pixelClock);
         samplesPerLine16_ = static_cast<int>(static_cast<uint64_t>(freq) * nPixPerLine * 65536 / pixelClock);
-        printf("setAudioFreq: %d Hz, CTS %d, N %d, %d samples/frame %d/65536 samples/line\n", freq, CTS, N, samplesPerFrame_,
-               samplesPerLine16_);
+     // Reconstructed Fs from CTS/N for diagnostics
+     double reconstructedFs = (double)pixelClock * (double)N / (128.0 * (double)CTS);
+     double ppmError = (reconstructedFs - freq) * 1e6 / freq;
+     printf("setAudioFreq: req %d Hz, CTS %d, N %d, recon %.3f Hz (%.1f ppm), %d samples/frame %d/65536 samples/line\n",
+         freq, CTS, N, reconstructedFs, ppmError, samplesPerFrame_, samplesPerLine16_);
+
+     // Reset internal audio packet scheduling state so a runtime switch is clean.
+     audioSamplePos_ = 0;
+     leftAudioSampleCount_ = 0;
+     pendingAudioLineCount_ = 0;
+     audioFrameCount_ = 0;
 
         enableDataIsland();
     }

--- a/dvi/timing.cpp
+++ b/dvi/timing.cpp
@@ -5,14 +5,14 @@
 
 #include "timing.h"
 #include <pico.h>
-#ifndef CPUKFREQKHZ
-#define CPUKFREQKHZ 252000
-#endif
+
 namespace dvi
 {
     namespace
     {
-        const Timing __not_in_flash_func(timing640x480p60_) = {
+        // Base timing template; pixel clock filled dynamically when requested
+        //const Timing __not_in_flash_func(timing640x480p60_) = {
+        const Timing timing640x480p60_ = {
             .hSyncPolarity = false,
             .hFrontPorch = 16,
             .hSyncWidth = 96,
@@ -25,13 +25,18 @@ namespace dvi
             .vBackPorch = 33,
             .vActiveLines = 480,
 
-            .bitClockKHz = CPUKFREQKHZ,
+            .bitClockKHz = 252000, // placeholder; real value substituted at retrieval
         };
     }
 
     const Timing *getTiming640x480p60Hz()
     {
-        return &timing640x480p60_;
+        static Timing dynamicTiming;
+        dynamicTiming = timing640x480p60_;
+        uint32_t hz = clock_get_hz(clk_sys);
+        dynamicTiming.bitClockKHz = hz / 1000; // truncate to kHz
+        return &dynamicTiming;
+       // return &timing640x480p60_;
     }
 
     uint32_t

--- a/dvi/timing.h
+++ b/dvi/timing.h
@@ -6,7 +6,7 @@
 #define CC31A9F7_8134_63A8_5DED_6FB68E08C7AE
 
 #include <stdint.h>
-
+#include "hardware/clocks.h"
 namespace dvi
 {
     struct Timing
@@ -27,7 +27,10 @@ namespace dvi
 
         uint32_t getPixelsPerLine() const;
         uint32_t getPixelsPerFrame() const;
-        uint32_t getPixelClock() const { return bitClockKHz * 100; }
+        uint32_t getPixelClock() const { 
+            return bitClockKHz * 100; 
+            //return clock_get_hz(clk_sys);
+        }
     };
 
     const Timing *getTiming640x480p60Hz();

--- a/util/queue.h
+++ b/util/queue.h
@@ -10,10 +10,121 @@
 #include <vector>
 #include <mutex>
 #include <assert.h>
+#include <pico.h>
 
 namespace util
 {
+#if 1
     template <class T>
+    class Queue
+    {
+        // Lock protects head_, tail_, count_, and storage_ writes.
+        SpinLock spinlock_;
+        std::vector<T> storage_; // fixed capacity after ctor
+        size_t head_ = 0;  // index of next element to pop
+        size_t tail_ = 0;  // index of next slot to push
+        size_t count_ = 0; // number of valid elements
+
+    public:
+        Queue(size_t n = 0)
+        {
+            storage_.resize(n); // actual size used as capacity storage
+        }
+
+        size_t capacity() const { return storage_.size(); }
+
+        __attribute__((always_inline)) size_t size()
+        {
+            std::lock_guard lock(spinlock_);
+            return count_;
+        }
+
+        __attribute__((always_inline)) bool empty()
+        {
+            std::lock_guard lock(spinlock_);
+            return count_ == 0;
+        }
+
+        __attribute__((always_inline)) const T &peek()
+        {
+            std::lock_guard lock(spinlock_);
+            assert(count_ > 0);
+            return storage_[head_];
+        }
+
+        // Returns false if full
+        __attribute__((always_inline)) bool enque(T &&v)
+        {
+            bool ok = false;
+            {
+                std::lock_guard lock(spinlock_);
+                if (count_ < storage_.size())
+                {
+                    storage_[tail_] = std::move(v);
+                    tail_ = (tail_ + 1) % storage_.size();
+                    ++count_;
+                    ok = true;
+                }
+            }
+            if (ok) __sev();
+            return ok;
+        }
+
+        // Non-blocking attempt. Returns true and assigns out if element present.
+        __attribute__((always_inline)) bool tryDeque(T &out)
+        {
+            std::lock_guard lock(spinlock_);
+            if (!count_) return false;
+            out = std::move(storage_[head_]);
+            head_ = (head_ + 1) % storage_.size();
+            --count_;
+            return true;
+        }
+
+        // Blocking dequeue; optional spin limit (0 = infinite) to detect stalls.
+        __attribute__((always_inline)) T deque(uint32_t spinLimit = 0)
+        {
+            uint32_t spins = 0;
+            while (true)
+            {
+                {
+                    std::lock_guard lock(spinlock_);
+                    if (count_)
+                    {
+                        T r = std::move(storage_[head_]);
+                        head_ = (head_ + 1) % storage_.size();
+                        --count_;
+                        return r;
+                    }
+                }
+                if (spinLimit && ++spins > spinLimit)
+                {
+                    // Diagnostic panic to avoid endless loop.
+                    panic("Queue::deque timeout (capacity=%u)\n", (unsigned)storage_.size());
+                }
+                __wfe();
+            }
+        }
+
+        void waitUntilContentAvailable(uint32_t spinLimit = 0)
+        {
+            uint32_t spins = 0;
+            while (true)
+            {
+                {
+                    std::lock_guard lock(spinlock_);
+                    if (count_) return;
+                }
+                if (spinLimit && ++spins > spinLimit)
+                {
+                    panic("Queue::wait timeout (capacity=%u)\n", (unsigned)storage_.size());
+                }
+                __wfe();
+            }
+        }
+    };
+#else
+     template <class T>
     class Queue
     {
         SpinLock spinlock_;
@@ -78,6 +189,7 @@ namespace util
             }
         }
     };
+#endif
 }
 
 #endif /* _25D39DD1_F134_63AD_3D0E_530B55A72531 */

--- a/util/queue.h
+++ b/util/queue.h
@@ -14,16 +14,38 @@
 
 namespace util
 {
-#if 1
+
+#if PICO_RP2350
+    // below a copilot assisted version of this class which prevents the DVI Driver from locking up
+    // The lockup only occurs when using a framebuffer and the GenesisPlus Emulator
+    // For RP2040, the original code is used.
+    //
+    // What changed:
+    // - Replaced std::vector push + erase pattern (which was O(n) and risked capacity misuse) with a fixed-size circular buffer (head/tail/count).
+    // - Added capacity(), empty(), and tryDeque() helpers.
+    // - enque now returns bool (fails gracefully if full instead of asserting only).
+    // - Added optional spin limits to deque(spinLimit) and waitUntilContentAvailable(spinLimit) that will panic with a diagnostic instead of looping forever.
+    // - Removed costly erase(begin()) (which could invalidate assumptions and cause subtle races if capacity reserve differed from size usage).
+    //
+    // Why this helps your random endless loop
+    //
+    // - Previous code relied on reserve() then push_back() and erase(begin()). If something elsewhere accidentally called queue_.resize() (or a reallocation occurred due to reserve mismatch during changes), the assertion path or timing could leave the consumer sleeping forever if a lost __sev() happens between empty checks.
+    // - The new ring buffer always keeps elements in-place and uses __sev() only when an actual enqueue succeeds, reducing missed wake events.
+    //
+    // Follow-up suggestions
+    //
+    // - Audit all enque() call sites: they should now check the returned bool (or you can wrap with an assert if overflow is unacceptable).
+    // - If you want a build-time safety net, define a macro to map old enque(x); usage to something that asserts the return value.
+    // - Consider instrumenting if panics occur (spinLimit argument) by supplying a non-zero spinLimit in critical dequeue sites during debugging.
     template <class T>
     class Queue
     {
         // Lock protects head_, tail_, count_, and storage_ writes.
         SpinLock spinlock_;
         std::vector<T> storage_; // fixed capacity after ctor
-        size_t head_ = 0;  // index of next element to pop
-        size_t tail_ = 0;  // index of next slot to push
-        size_t count_ = 0; // number of valid elements
+        size_t head_ = 0;        // index of next element to pop
+        size_t tail_ = 0;        // index of next slot to push
+        size_t count_ = 0;       // number of valid elements
 
     public:
         Queue(size_t n = 0)
@@ -66,7 +88,8 @@ namespace util
                     ok = true;
                 }
             }
-            if (ok) __sev();
+            if (ok)
+                __sev();
             return ok;
         }
 
@@ -74,7 +97,8 @@ namespace util
         __attribute__((always_inline)) bool tryDeque(T &out)
         {
             std::lock_guard lock(spinlock_);
-            if (!count_) return false;
+            if (!count_)
+                return false;
             out = std::move(storage_[head_]);
             head_ = (head_ + 1) % storage_.size();
             --count_;
@@ -113,7 +137,8 @@ namespace util
             {
                 {
                     std::lock_guard lock(spinlock_);
-                    if (count_) return;
+                    if (count_)
+                        return;
                 }
                 if (spinLimit && ++spins > spinLimit)
                 {
@@ -124,7 +149,7 @@ namespace util
         }
     };
 #else
-     template <class T>
+    template <class T>
     class Queue
     {
         SpinLock spinlock_;

--- a/util/queue.h
+++ b/util/queue.h
@@ -149,6 +149,7 @@ namespace util
         }
     };
 #else
+    // The original implementation for non-RP2350 targets
     template <class T>
     class Queue
     {


### PR DESCRIPTION
- Changes in audio when cpu is clocked at a higher speed than 252MHZ. Calculate CTS when passed as 0 in DVI::setAudioFreq
- Refactor queue.h for RP2350 to avoid lockups when framebuffer is used. 