### PR TITLE
Fix HDMI audio dropout by sending silence packets on buffer underflow

### DIFF
--- a/dvi/dvi.cpp
+++ b/dvi/dvi.cpp
@@ -198,18 +198,6 @@ namespace dvi
                 return false;
             }
 
-            if (pendingAudioLineCount_)
-            {
-                --pendingAudioLineCount_;
-                return false;
-            }
-            if (audioSampleRing_.getReadableSize() == 0)
-            {
-                // pendingAudioLineCount_ = 1024; // 枯渇しているようなら 2 frame くらい待ってみる
-                // Backoff for approximately 1 video frame instead of large static penalty
-                pendingAudioLineCount_ = timing_->vFrontPorch + timing_->vSyncWidth + timing_->vBackPorch + timing_->vActiveLines;
-            }
-
             audioSamplePos_ += samplesPerLine16_;
 
             if (lineState_ == LineState::FRONT_PORCH)
@@ -234,31 +222,24 @@ namespace dvi
                 }
             }
 
-#if 0
-            if (leftAudioSampleCount_)
-            {
-                const auto n = std::min(leftAudioSampleCount_, std::min<int>(audioSampleRing_.getReadableSize(), 2));
-                if (n)
-                {
-                    const auto *p = audioSampleRing_.getReadPointer();
-                    audioFrameCount_ = packet.setAudioSample(p, n, audioFrameCount_);
-                    audioSampleRing_.advanceReadPointer(n);
-                    leftAudioSampleCount_ -= n;
-                    return true;
-                }
-            }
-#else
-            //            audioSamplePos_ += samplesPerLine16_;
-            int n = std::max(0, std::min(4, std::min<int>(audioSamplePos_ >> 16, audioSampleRing_.getReadableSize())));
-            audioSamplePos_ -= n << 16;
-            if (n)
+            int due = std::max(0, std::min(4, static_cast<int>(audioSamplePos_ >> 16)));
+            int avail = audioSampleRing_.getReadableSize();
+            int n = std::min(due, avail);
+            if (n > 0)
             {
                 const auto *p = audioSampleRing_.getReadPointer();
                 audioFrameCount_ = packet.setAudioSample(p, n, audioFrameCount_);
                 audioSampleRing_.advanceReadPointer(n);
+                audioSamplePos_ -= n << 16;
                 return true;
             }
-#endif
+            if (due > 0)
+            {
+                static const AudioSample silence[4] = {};
+                audioFrameCount_ = packet.setAudioSample(silence, due, audioFrameCount_);
+                audioSamplePos_ -= due << 16;
+                return true;
+            }
 
             return false;
         };


### PR DESCRIPTION
This pull request refactors the audio sample handling logic in the `dvi/dvi.cpp` file, simplifying how audio samples are read and silence is inserted when needed. The changes focus on removing legacy code and improving clarity and efficiency in the audio processing section.

**Audio sample handling improvements:**

* Removed the use of `pendingAudioLineCount_` and the associated backoff logic, streamlining the flow for when the audio sample ring is empty.
* Replaced the old conditional and commented-out code for audio sample reading with a clearer approach that calculates the number of due samples, reads available samples, and inserts silence if not enough samples are available.
* Ensured that `audioSamplePos_` is updated consistently when samples are read or silence is inserted, maintaining accurate audio timing.

Instead of backing off all audio packets when the ring buffer underflows, continue sending silence audio sample packets to keep the HDMI audio clock regeneration stream unbroken. This prevents displays from losing audio PLL lock during NSF track changes and other momentary audio gaps.